### PR TITLE
18 client

### DIFF
--- a/pre-push
+++ b/pre-push
@@ -2,7 +2,7 @@
 
 echo "Running pre-push tests..."
 
-go test -v ./redis/cmd # ??
+go test -v ./...
 
 if [ $? -ne 0 ]; then
     echo "Tests failed! Aborting push."

--- a/rediscli/client.go
+++ b/rediscli/client.go
@@ -53,6 +53,10 @@ func (c *Client) Incrby (key string, value int) string {
 	return sendDBCommand("incrby "+key+" "+strconv.Itoa(value), c.servers, c.servers[0])
 }
 
+func (c *Client) Close () string {
+	return sendDBCommand("exit", c.servers, c.servers[0])
+}
+
 func sendDBCommand(command string, servers []Server, readServer Server) string {
 	// I will send command to all the servers
 	// Currently waiting for the response from one server only

--- a/rediscli/client.go
+++ b/rediscli/client.go
@@ -1,0 +1,96 @@
+package rediscli
+
+import (
+	"net"
+	"strconv"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+// TODO: Clear the below thoughts after implementing cli
+
+// Currently, I am using telnet client to send commands to my server
+// This is enough for now, but I need more control over the client when I and implementing quorum based replication
+
+// For now I will create a simple client which will create a connection, send and receive data from the server
+
+
+type Server struct {
+	id  uuid.UUID
+	conn *net.Conn
+}
+
+type Client struct {
+	servers []Server
+}
+
+func (c *Client) Set (key string, value string) string {
+	// I will send the command to all the servers
+	// For now I will wait for the response from one server only
+	// TODO: Implement quorum based replication
+
+	return sendDBCommand("set "+key+" "+value, c.servers, c.servers[0])
+}
+
+func (c *Client) Get (key string) string {
+	// I will send the command to all the servers
+	// For now I will wait for the response from one server only
+	// TODO: Implement quorum based replication
+	return sendDBCommand("get "+key, c.servers, c.servers[0])
+}
+
+func (c *Client) Del (keys []string) string {
+	// TODO: test with keys having spaces
+	return sendDBCommand("del "+strings.Join(keys, " "), c.servers, c.servers[0])
+}
+
+func (c *Client) Incr (key string) string {
+	return sendDBCommand("incr "+key, c.servers, c.servers[0])
+}
+
+func (c *Client) Incrby (key string, value int) string {
+	return sendDBCommand("incrby "+key+" "+strconv.Itoa(value), c.servers, c.servers[0])
+}
+
+func sendDBCommand(command string, servers []Server, readServer Server) string {
+	// I will send command to all the servers
+	// Currently waiting for the response from one server only
+	for _, server := range servers {
+		conn := *server.conn
+		_, err := conn.Write([]byte(command + "\n"))
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	// Read the response from the server
+	buffer := make([]byte, 4096)
+	readConn := *readServer.conn
+	n, err := readConn.Read(buffer)
+	if err != nil {
+		panic(err)
+	}
+	return string(buffer[:n])
+}
+
+func createConnection (host string, port string) *net.Conn {
+	conn, err := net.Dial("tcp", host+":"+port)
+	if err != nil {
+		panic(err)
+	}
+	return &conn
+}	
+
+func NewClient(host, port string) *Client {
+		servers := []Server{
+			{	
+				id : uuid.New(),  // I should get this id from server.
+				conn: createConnection(host, port),
+			},
+		}
+	return &Client{
+		servers: servers,
+	}
+}
+

--- a/rediscli/client_test.go
+++ b/rediscli/client_test.go
@@ -38,13 +38,6 @@ func handleMockedRequest (conn net.Conn) {
 			conn.Close()
 			return
 		}
-
-		if message == "exit\n" {
-			conn.Write([]byte("connection closed\n"))
-			conn.Close()
-			return
-		}
-
 		_, _ = conn.Write([]byte(message))
 	}
 }
@@ -70,6 +63,7 @@ func Test_mockedServer(t *testing.T) {
 		{client.Del([]string{"key1", "key2"}), "del key1 key2\n"},
 		{client.Incr("key"), "incr key\n"},
 		{client.Incrby("key", 3), "incrby key 3\n"},
+		{client.Close(), "exit\n"},
 	}
 
 	for _, test := range tests {
@@ -77,5 +71,4 @@ func Test_mockedServer(t *testing.T) {
 			t.Errorf("Expected <<%v>> Got <<%v>>", test.expected, test.funcCall)
 		}
 	}
-
 }

--- a/rediscli/client_test.go
+++ b/rediscli/client_test.go
@@ -1,0 +1,81 @@
+package rediscli
+
+import (
+	"bufio"
+	"fmt"
+	"log"
+	"net"
+	"testing"
+	"time"
+)
+
+
+func runMockedServer (host, port string) {
+	listener, err := net.Listen("tcp", fmt.Sprintf("%s:%s", host, port))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println("Mocked server listening to ", host, ":", port)
+	defer listener.Close()
+
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		go handleMockedRequest(conn)
+	}
+}
+
+func handleMockedRequest (conn net.Conn) {
+	reader := bufio.NewReader(conn)
+
+	for {
+		message, err := reader.ReadString('\n')
+		if err != nil {
+			conn.Close()
+			return
+		}
+
+		if message == "exit\n" {
+			conn.Write([]byte("connection closed\n"))
+			conn.Close()
+			return
+		}
+
+		_, _ = conn.Write([]byte(message))
+	}
+}
+
+func Test_mockedServer(t *testing.T) {
+
+	// In for this test I will test my client with a mocked tcp servers.
+	// The servers will always return the same command back to the client.
+
+	host, port := "localhost", "8085"
+	go runMockedServer(host, port)
+
+	conn, _ := net.DialTimeout("tcp", host+":"+port, 5*time.Second)
+	defer conn.Close()
+
+	client := NewClient(host, port)
+	
+	tests := []struct {
+		funcCall, expected string
+	}{
+		{client.Set("key", "value"), "set key value\n"},
+		{client.Get("key"), "get key\n"},
+		{client.Del([]string{"key1", "key2"}), "del key1 key2\n"},
+		{client.Incr("key"), "incr key\n"},
+		{client.Incrby("key", 3), "incrby key 3\n"},
+	}
+
+	for _, test := range tests {
+		if test.funcCall != test.expected{
+			t.Errorf("Expected <<%v>> Got <<%v>>", test.expected, test.funcCall)
+		}
+	}
+
+}


### PR DESCRIPTION
A simple client package to handle get, set, del and exit in go added. 
Currently this client package is writing to all the servers, but reading fetching response from first server only. 
I can add a hybrid quorum based replication to this client.